### PR TITLE
Add Woven Imprint — persistent character memory extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -402,5 +402,12 @@
         "name": "Pronouns",
         "description": "Manage your persona's pronouns.",
         "url": "https://github.com/Wolfsblvt/SillyTavern-Pronouns"
+    },
+    {
+        "id": "sillytavern-woven-imprint",
+        "type": "extension",
+        "name": "Woven Imprint",
+        "description": "Persistent character memory and relationship tracking. Additional software is required, see the README.",
+        "url": "https://github.com/virtaava/sillytavern-woven-imprint"
     }
 ]

--- a/index.json
+++ b/index.json
@@ -590,5 +590,12 @@
     "name": "Pronouns",
     "description": "Manage your persona's pronouns.",
     "url": "https://github.com/Wolfsblvt/SillyTavern-Pronouns"
+  },
+  {
+    "id": "sillytavern-woven-imprint",
+    "type": "extension",
+    "name": "Woven Imprint",
+    "description": "Persistent character memory and relationship tracking. Additional software is required, see the README.",
+    "url": "https://github.com/virtaava/sillytavern-woven-imprint"
   }
 ]


### PR DESCRIPTION
## Summary

Adds [Woven Imprint](https://github.com/virtaava/sillytavern-woven-imprint) to the extension listing.

**What it does:** Gives SillyTavern characters persistent memory and relationship tracking. Characters remember past conversations across sessions, form opinions about the user, and develop relationships (trust, affection, tension) that evolve over time. All data stored locally in SQLite.

**How it works:** A Python sidecar ([woven-imprint](https://github.com/virtaava/woven-imprint), Apache 2.0, on PyPI) runs alongside SillyTavern. The extension records dialogue via `MESSAGE_SENT`/`MESSAGE_RECEIVED` events and injects relevant memories into prompts via `setExtensionPrompt()` — same pattern as the built-in memory extension.

**Requirements:** `pip install woven-imprint` + an LLM backend for fact extraction (Ollama, OpenAI, etc.)

- Apache 2.0 licensed
- Compatible with latest SillyTavern release
- Server plugin + UI extension
- [Documentation](https://github.com/virtaava/sillytavern-woven-imprint/blob/master/README.md)