### PR TITLE
Added SillyTavern-WI-FunctionCall

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -409,5 +409,13 @@
         "name": "Message Collapser",
         "description": "Automatically collapse long messages in chat with configurable threshold. Accessibility-friendly UI enhancement.",
         "url": "https://github.com/Crystaria/SillyTavern-MessageCollapser"
+    },
+    {
+        "id": "SillyTavern-WI-FunctionCall",
+        "type": "extension",
+        "name": "World Info Function Call",
+        "description": "Enables your model to activate World Info / lorebook entries on-demand via function calling, during text generation.",
+        "url": "https://github.com/Culpeo/SillyTavern-WI-FunctionCall",
+        "tool": true
     }
 ]

--- a/index.json
+++ b/index.json
@@ -597,5 +597,13 @@
     "name": "Message Collapser",
     "description": "Automatically collapse long messages in chat with configurable threshold. Accessibility-friendly UI enhancement.",
     "url": "https://github.com/Crystaria/SillyTavern-MessageCollapser"
+  },
+  {
+    "id": "SillyTavern-WI-FunctionCall",
+    "type": "extension",
+    "name": "World Info Function Call",
+    "description": "Enables your model to activate World Info / lorebook entries on-demand via function calling, during text generation.",
+    "url": "https://github.com/Culpeo/SillyTavern-WI-FunctionCall",
+    "tool": true
   }
 ]


### PR DESCRIPTION
Follow-up for [https://github.com/SillyTavern/SillyTavern/pull/5422](https://github.com/SillyTavern/SillyTavern/pull/5422).

This extension lets AI models activate World Info / lorebook entries on demand via function calling, instead of relying on keyword matching or static context injection.

Link to the extension: https://github.com/Culpeo/SillyTavern-WI-FunctionCall