### PR TITLE
Add video avatars extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -466,5 +466,12 @@
         "name": "Model Injection",
         "description": "Constant WI injection for /model (use with outlets for automatic model-specific prompts).",
         "url": "https://github.com/aikohanasaki/SillyTavern-ModelInjection"
-    }
+    },
+	{
+		"id": "SillyTavern-VideoAvatar",
+		"type": "extension",
+		"name": "Animated Character Images",
+		"description": "Upload a video to animate your character and persona images.",
+		"url": "https://github.com/Vibecoder9000/SillyTavern-VideoAvatar"
+	}
 ]

--- a/index.json
+++ b/index.json
@@ -654,5 +654,12 @@
     "name": "Model Injection",
     "description": "Constant WI injection for /model (use with outlets for automatic model-specific prompts).",
     "url": "https://github.com/aikohanasaki/SillyTavern-ModelInjection"
+  },
+  {
+    "id": "SillyTavern-VideoAvatar",
+    "type": "extension",
+    "name": "Animated Character Images",
+    "description": "Upload a video to animate your character and persona images.",
+    "url": "https://github.com/Vibecoder9000/SillyTavern-VideoAvatar"
   }
 ]


### PR DESCRIPTION
This adds the video avatars extension. It scans the HTML for the correct persona and character images and replaces them with user media. It requires ![ffmpeg](https://github.com/SillyTavern/Extension-VideoBackgroundLoader). It doesn't replace the png on export. I've bug tested UI interactions.

Let me know if you have any questions.