### PR TITLE
Add API Key 管家 extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -466,5 +466,12 @@
         "name": "Model Injection",
         "description": "Constant WI injection for /model (use with outlets for automatic model-specific prompts).",
         "url": "https://github.com/aikohanasaki/SillyTavern-ModelInjection"
+    },
+    {
+        "id": "SillyTavern-API-Key-Manager",
+        "type": "extension",
+        "name": "API Key 管家",
+        "description": "OpenAI-compatible LLM service, model, and API key persistence console.",
+        "url": "https://github.com/yexi-by/SillyTavern-API-Key-Manager"
     }
 ]

--- a/index.json
+++ b/index.json
@@ -654,5 +654,12 @@
     "name": "Model Injection",
     "description": "Constant WI injection for /model (use with outlets for automatic model-specific prompts).",
     "url": "https://github.com/aikohanasaki/SillyTavern-ModelInjection"
+  },
+  {
+    "id": "SillyTavern-API-Key-Manager",
+    "type": "extension",
+    "name": "API Key \u7ba1\u5bb6",
+    "description": "OpenAI-compatible LLM service, model, and API key persistence console.",
+    "url": "https://github.com/yexi-by/SillyTavern-API-Key-Manager"
   }
 ]


### PR DESCRIPTION
## Summary\n- Add API Key 管家 to the extension asset index.\n- Regenerate index.json using generate_index_json.py.\n\n## Extension\n- Repository: https://github.com/yexi-by/SillyTavern-API-Key-Manager\n- Type: UI Extension\n- Purpose: OpenAI-compatible LLM service, model, and API key persistence console.\n\n## Checklist\n- The extension is open source and includes a license.\n- The extension has README documentation and installation instructions.\n- The extension does not require a server plugin.\n- API keys are stored through SillyTavern secrets, not extension settings.