### PR TITLE
Add Intiface Central extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -466,5 +466,12 @@
         "name": "Model Injection",
         "description": "Constant WI injection for /model (use with outlets for automatic model-specific prompts).",
         "url": "https://github.com/aikohanasaki/SillyTavern-ModelInjection"
+    },
+    {
+        "id": "Intiface_Central-Sillytavern-plugin",
+        "type": "extension",
+        "name": "Intiface Central for SillyTavern",
+        "description": "Connects SillyTavern to Intiface Desktop for manual and chat-driven control of compatible devices.",
+        "url": "https://github.com/Enclave0775/Intiface_Central-Sillytavern-plugin"
     }
 ]

--- a/index.json
+++ b/index.json
@@ -654,5 +654,12 @@
     "name": "Model Injection",
     "description": "Constant WI injection for /model (use with outlets for automatic model-specific prompts).",
     "url": "https://github.com/aikohanasaki/SillyTavern-ModelInjection"
+  },
+  {
+    "id": "Intiface_Central-Sillytavern-plugin",
+    "type": "extension",
+    "name": "Intiface Central for SillyTavern",
+    "description": "Connects SillyTavern to Intiface Desktop for manual and chat-driven control of compatible devices.",
+    "url": "https://github.com/Enclave0775/Intiface_Central-Sillytavern-plugin"
   }
 ]


### PR DESCRIPTION
Adds Intiface Central for SillyTavern to the third-party extensions list.

The extension connects SillyTavern to Intiface Desktop for manual and chat-driven control of compatible devices.
