### PR TITLE
Add Picture Prompt extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -466,5 +466,12 @@
         "name": "Model Injection",
         "description": "Constant WI injection for /model (use with outlets for automatic model-specific prompts).",
         "url": "https://github.com/aikohanasaki/SillyTavern-ModelInjection"
+    },
+    {
+        "id": "SillyTavern-PicturePrompt",
+        "type": "extension",
+        "name": "Picture Prompt",
+        "description": "Vision models can see, but by default they're blind. Injects avatars, reference art, and lorebook images automatically.",
+        "url": "https://github.com/RetroVioletRed/SillyTavern-PicturePrompt"
     }
 ]

--- a/index.json
+++ b/index.json
@@ -654,5 +654,12 @@
     "name": "Model Injection",
     "description": "Constant WI injection for /model (use with outlets for automatic model-specific prompts).",
     "url": "https://github.com/aikohanasaki/SillyTavern-ModelInjection"
+  },
+  {
+    "id": "SillyTavern-PicturePrompt",
+    "type": "extension",
+    "name": "Picture Prompt",
+    "description": "Vision models can see, but by default they're blind. Injects avatars, reference art, and lorebook images automatically.",
+    "url": "https://github.com/RetroVioletRed/SillyTavern-PicturePrompt"
   }
 ]


### PR DESCRIPTION
Extension that injects character avatars, persona images, gallery pins, and lorebook entry images into vision model prompts — with per-image toggles, custom labels, and live token estimation.

### Requirements check
- [x] AGPLv3 licensed
- [x] No server plugin dependency (client-side only)
- [x] Compatible with ST 1.14+
- [x] README with install instructions, features, and FAQ

### Links
- Repo: https://github.com/RetroVioletRed/SillyTavern-PicturePrompt
- Manifest: `public/scripts/extensions/third-party/SillyTavern-PicturePrompt/manifest.json`

Thanks!