### PR TITLE
Add MYTURN extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -466,5 +466,12 @@
         "name": "Model Injection",
         "description": "Constant WI injection for /model (use with outlets for automatic model-specific prompts).",
         "url": "https://github.com/aikohanasaki/SillyTavern-ModelInjection"
+    },
+    {
+        "id": "MYTURN",
+        "type": "extension",
+        "name": "MYTURN",
+        "description": "Turns the browser tab favicon into a generation status light: a spinner while the LLM replies, and a checkmark (that stays until you return to the tab) when it's your turn.",
+        "url": "https://github.com/Blooshoo/MYTURN"
     }
 ]

--- a/index.json
+++ b/index.json
@@ -654,5 +654,12 @@
     "name": "Model Injection",
     "description": "Constant WI injection for /model (use with outlets for automatic model-specific prompts).",
     "url": "https://github.com/aikohanasaki/SillyTavern-ModelInjection"
+  },
+  {
+    "id": "MYTURN",
+    "type": "extension",
+    "name": "MYTURN",
+    "description": "Turns the browser tab favicon into a generation status light: a spinner while the LLM replies, and a checkmark (that stays until you return to the tab) when it's your turn.",
+    "url": "https://github.com/Blooshoo/MYTURN"
   }
 ]


### PR DESCRIPTION
Adds **MYTURN** to the extensions index.

**Repo:** https://github.com/Blooshoo/MYTURN

### What it does
Turns the browser tab favicon into a generation status light:
- 🔵 Spinner while the LLM is generating a reply
- ✅ Checkmark when it's done — persists until you return to the tab (optional auto-hide after X seconds)
- ↩️ Reverts to the normal favicon when you come back

Handy when a turn takes a couple of minutes and you tab away to do other things.

### Checklist
- [x] Open-source, libre license (MIT)
- [x] Compatible with the latest SillyTavern release
- [x] No server plugin dependencies (pure client-side; uses the official `GENERATION_*` events)
- [x] README with install instructions, usage, and feature list
- [x] Regenerated `index.json` via `generate_index_json.py`