### PR TITLE
Add Group Compact Panel extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -466,5 +466,12 @@
         "name": "Model Injection",
         "description": "Constant WI injection for /model (use with outlets for automatic model-specific prompts).",
         "url": "https://github.com/aikohanasaki/SillyTavern-ModelInjection"
+    },
+    {
+        "id": "SillyTavern-GroupCompactPanel",
+        "type": "extension",
+        "name": "Group Compact Panel",
+        "description": "Adds a compact floating panel for quickly managing members in group chats.",
+        "url": "https://github.com/cloudmel/sillytavern-group-compact-panel"
     }
 ]

--- a/index.json
+++ b/index.json
@@ -654,5 +654,12 @@
     "name": "Model Injection",
     "description": "Constant WI injection for /model (use with outlets for automatic model-specific prompts).",
     "url": "https://github.com/aikohanasaki/SillyTavern-ModelInjection"
+  },
+  {
+    "id": "SillyTavern-GroupCompactPanel",
+    "type": "extension",
+    "name": "Group Compact Panel",
+    "description": "Adds a compact floating panel for quickly managing members in group chats.",
+    "url": "https://github.com/cloudmel/sillytavern-group-compact-panel"
   }
 ]


### PR DESCRIPTION
Adds Group Compact Panel to the official SillyTavern extension index.

Group Compact Panel is a compact floating UI for quickly managing members in group chats. It provides quick access to character cards, Speak, Enable/Disable actions, queue order, and drag-and-drop positioning.

The extension is open source and MIT licensed. Installation and usage instructions are included in the repository README.