### PR TITLE
Add Chat Collections extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -466,5 +466,12 @@
         "name": "Model Injection",
         "description": "Constant WI injection for /model (use with outlets for automatic model-specific prompts).",
         "url": "https://github.com/aikohanasaki/SillyTavern-ModelInjection"
+    },
+    {
+        "id": "SillyTavern-Chat-Collections",
+        "type": "extension",
+        "name": "Chat Collections",
+        "description": "Organize saved solo and group chats into nested virtual collections without moving or rewriting chat files.",
+        "url": "https://github.com/starcore42/SillyTavern-Chat-Collections"
     }
 ]

--- a/index.json
+++ b/index.json
@@ -654,5 +654,12 @@
     "name": "Model Injection",
     "description": "Constant WI injection for /model (use with outlets for automatic model-specific prompts).",
     "url": "https://github.com/aikohanasaki/SillyTavern-ModelInjection"
+  },
+  {
+    "id": "SillyTavern-Chat-Collections",
+    "type": "extension",
+    "name": "Chat Collections",
+    "description": "Organize saved solo and group chats into nested virtual collections without moving or rewriting chat files.",
+    "url": "https://github.com/starcore42/SillyTavern-Chat-Collections"
   }
 ]


### PR DESCRIPTION
## Summary
- add Chat Collections to the endorsed extension catalogue
- regenerate the content index

## Extension
Chat Collections provides nested virtual folders for saved solo and group chats. It does not move or rewrite chat files and has no server plugin dependency.

Repository: https://github.com/starcore42/SillyTavern-Chat-Collections

## Checklist
- [x] Open source under AGPL-3.0
- [x] Compatible with SillyTavern 1.18.x
- [x] README includes installation, usage, features, and screenshot
- [x] No server plugin requirement